### PR TITLE
chore: pin gh-actions to v1

### DIFF
--- a/.github/workflows/scrut.yml
+++ b/.github/workflows/scrut.yml
@@ -20,7 +20,7 @@ jobs:
           rustup default stable
 
       - name: Install scrut
-        uses: cboone/gh-actions/actions/setup-scrut@main
+        uses: cboone/gh-actions/actions/setup-scrut@v1
 
       - name: Run Scrut tests
         run: scrut test -w . tests


### PR DESCRIPTION
## Summary

- Pin `cboone/gh-actions` references from `@main` to `@v1`

The gh-actions repo has been tagged with v1.0.0. Using the floating `@v1` tag ensures we automatically pick up non-breaking updates while maintaining stability.