### PR TITLE
chore: pin gh-actions to v2.1.2

### DIFF
--- a/.github/workflows/scrut.yml
+++ b/.github/workflows/scrut.yml
@@ -20,7 +20,7 @@ jobs:
           rustup default stable
 
       - name: Install scrut
-        uses: cboone/gh-actions/actions/setup-scrut@v1
+        uses: cboone/gh-actions/actions/setup-scrut@v2.1.2
 
       - name: Run Scrut tests
         run: scrut test -w . tests


### PR DESCRIPTION
Pin all `cboone/gh-actions` workflow and action references from floating
tags (`@v1`, `@v2`) to the exact version `@v2.1.2`.

Part of the migration to exact-version-only tagging (cboone/gh-actions#25).
After all consuming repos are updated, the floating `v1` and `v2` tags
will be deleted from the gh-actions remote.